### PR TITLE
Updates for python 3.10 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 requests>=2.12.3
 requests_oauthlib>=0.6.2
-requests_toolbelt>=0.7.0
 msgpack-python>=0.4.8
 responses>=0.5.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,6 @@ setup(name='unicheck',
       install_requires=[
             'requests>=2.12.3',
             'requests_oauthlib>=0.6.2',
-            'requests_toolbelt>=0.7.0',
             'msgpack>=0.5.6',
             'responses>=0.5.1',
       ],

--- a/unicheck/file.py
+++ b/unicheck/file.py
@@ -3,7 +3,6 @@ This module represents file abstraction in Unicheck.
 """
 
 from os.path import splitext
-from requests_toolbelt import MultipartEncoder
 from msgpack import packb
 
 from .response import UnicheckMainException
@@ -61,10 +60,15 @@ class File(object):
 
         # Switch-case for type of upload
         if upload_type == 'multipart':
-            params = {'format': file_ext, 'file': ('check', open(path, 'rb'), 'application/' + file_ext)}
-            params.update(kwargs)
-            file = MultipartEncoder(fields=params)
-            resp = self.oauth_session.post(upload_url, data=file, headers={'Content-Type':  file.content_type}, timeout=timeout)
+            # This path used to be handled using a MultipartEncoder object
+            # provided by the requests_toolbelt library, but the upgrade of
+            # picasso to python 3.10 (see https://github.com/minervaproject/picasso/pull/11259)
+            # required the removal of requests_toolbelt, since there was no
+            # updated version of it that would be compatible. This code path
+            # is unused by picasso (in fact, the whole File API is unused),
+            # so we opt to just raise an exception here and move on with
+            # our lives.
+            raise Exception("Multipart uploads are no longer supported.")
 
         elif upload_type == 'msgpack':
             params = {'format': file_ext, 'file': open(path, 'rb').read()}


### PR DESCRIPTION
## Description for reviewers

#### Motivation for this PR

Upgrading picasso to python 3.10 (see https://app.asana.com/0/1200866257189754/1203367263294059/f and https://github.com/minervaproject/picasso/pull/11259) introduces a conflict for the `requests_toolbelt` package that `unicheck` depends on. Since picasso doesn't use the code path in question, we can just remove it. The need for the `unicheck` package will be obviated soon anyway when we [migrate to TurnItIn](https://app.asana.com/0/search?q=unicheck&child=1202864439568605&f=true)..

#### Related Asana task

https://app.asana.com/0/1200866257189754/1203367263294059/f

#### Deployment risk

How risky is this PR to deploy?

#### Roll out

- [ ] Feature flag
- [ ] 3-step migration
- [x] All at once

#### Security and performance

- [ ] Changes in this PR might dramatically impact performance
- [x] Security impact of change has been considered. See [this page](https://owasp.org/www-project-top-ten/) for common web applications security risks. In particular, "Sensitive Data Exposure" and "Broken Access Control" are frequently relevant to application changes.
- [x] Code follows [company security practices and guidelines](https://docs.google.com/document/d/1XxDzlVGWBwIv7FD54tkuSPufhtDAM3NWwSto0rzUsco/edit?usp=sharing)
